### PR TITLE
 Improve how Thaumcraft counts items when inserting into an inventory, thus preventing Thaumatoriums from overflowing and allowing double chests to get filled completely.

### DIFF
--- a/docs/bugfixes.md
+++ b/docs/bugfixes.md
@@ -133,3 +133,9 @@ Non-vertical silverwood logs will be correctly named "Silverwood Log" in WAILA.
 **Config option:** `updateBiomeColorRendering`
 
 Biome changes will correctly update the color of grass in chunks without needing a block to change.
+
+## Correct Item Insertion Logic
+
+**Config option:** `correctItemInsertion`
+
+Thaumcraft will correctly insect items into inventories - prevents double-counting slots when testing for space and allows insertion of items into an empty slot of the other side of a double chest.

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
@@ -135,6 +135,11 @@ public class ConfigBugfixes extends ConfigGroup {
         "updateBiomeColorRendering",
         "Biome changes will correctly update the color of grass in chunks without needing a block to change.");
 
+    public final ToggleSetting correctItemInsertion = new ToggleSetting(
+        this,
+        "correctItemInsertion",
+        "Thaumcraft will correctly insect items into inventories - prevents double-counting slots when testing for space and allows insertion of items into an empty slot of the other side of a double chest.");
+
     @Nonnull
     @Override
     public String getGroupName() {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -146,6 +146,11 @@ public enum Mixins {
         .setApplyIf(SalisConfig.bugfixes.updateBiomeColorRendering::isEnabled)
         .addMixinClasses("lib.MixinUtils_UpdateBiomeColor")
         .addTargetedMod(TargetedMod.THAUMCRAFT)),
+    ITEM_COUNTING_FIX(new Builder().setPhase(Phase.LATE)
+        .setSide(Side.BOTH)
+        .setApplyIf(SalisConfig.bugfixes.correctItemInsertion::isEnabled)
+        .addMixinClasses("lib.MixinInventoryUtils_AmountCounting")
+        .addTargetedMod(TargetedMod.THAUMCRAFT)),
 
     // Features
     EXTENDED_BAUBLES_SUPPORT(new Builder().setPhase(Phase.LATE)

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/lib/MixinInventoryUtils_AmountCounting.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/lib/MixinInventoryUtils_AmountCounting.java
@@ -1,0 +1,85 @@
+package dev.rndmorris.salisarcana.mixins.late.lib;
+
+import net.minecraft.init.Items;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntityChest;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+
+import thaumcraft.common.lib.utils.InventoryUtils;
+
+@Mixin(value = InventoryUtils.class, remap = false)
+public class MixinInventoryUtils_AmountCounting {
+
+    @Unique
+    private static final ItemStack sa$nonNullItemStack = new ItemStack(Items.stick);
+
+    @WrapOperation(
+        method = "insertStack",
+        at = @At(
+            value = "INVOKE",
+            target = "Lthaumcraft/common/lib/utils/InventoryUtils;attemptInsertion(Lnet/minecraft/inventory/IInventory;Lnet/minecraft/item/ItemStack;IIZ)Lnet/minecraft/item/ItemStack;",
+            ordinal = 1))
+    private static ItemStack checkForEmpty(IInventory inventory, ItemStack stack, int slot, int side, boolean doit,
+        Operation<ItemStack> original) {
+        if (inventory.getStackInSlot(slot) == null) {
+            return original.call(inventory, stack, slot, side, doit);
+        } else {
+            return stack;
+        }
+    }
+
+    @WrapOperation(
+        method = "insertStack",
+        at = @At(
+            value = "INVOKE",
+            target = "Lthaumcraft/common/lib/utils/InventoryUtils;attemptInsertion(Lnet/minecraft/inventory/IInventory;Lnet/minecraft/item/ItemStack;IIZ)Lnet/minecraft/item/ItemStack;",
+            ordinal = 4))
+    private static ItemStack checkForEmpty2(IInventory inventory, ItemStack stack, int slot, int side, boolean doit,
+        Operation<ItemStack> original) {
+        if (inventory.getStackInSlot(slot) == null) {
+            return original.call(inventory, stack, slot, side, doit);
+        } else {
+            return stack;
+        }
+    }
+
+    @WrapOperation(
+        method = "insertStack",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/tileentity/TileEntityChest;getStackInSlot(I)Lnet/minecraft/item/ItemStack;",
+            ordinal = 2,
+            remap = true))
+    private static ItemStack forceConditional(TileEntityChest instance, int slotIn, Operation<ItemStack> original) {
+        return instance.getStackInSlot(slotIn) == null ? sa$nonNullItemStack : null;
+    }
+
+    @WrapOperation(
+        method = "insertStack",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/tileentity/TileEntityChest;getStackInSlot(I)Lnet/minecraft/item/ItemStack;",
+            ordinal = 3,
+            remap = true))
+    private static ItemStack forceNonNull(TileEntityChest instance, int slotIn, Operation<ItemStack> original) {
+        return sa$nonNullItemStack;
+    }
+
+    @WrapOperation(
+        method = "insertStack",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/item/ItemStack;isItemEqual(Lnet/minecraft/item/ItemStack;)Z",
+            ordinal = 3,
+            remap = true))
+    private static boolean forceTruthy(ItemStack instance, ItemStack p_77969_1_, Operation<Boolean> original) {
+        return true;
+    }
+}


### PR DESCRIPTION
From https://github.com/rndmorris/Salis-Arcana/pull/268